### PR TITLE
Compatibility with Android < 2.3 and Java < 6

### DIFF
--- a/src/com/osbcp/cssparser/CSSParser.java
+++ b/src/com/osbcp/cssparser/CSSParser.java
@@ -44,7 +44,7 @@ public final class CSSParser {
 
 		List<Rule> rules = new ArrayList<Rule>();
 
-		if (css == null || css.trim().isEmpty()) {
+		if (css == null || css.trim().length() == 0) {
 			return rules;
 		}
 
@@ -321,7 +321,7 @@ public final class CSSParser {
 
 		} else if (Chars.COMMA.equals(c)) {
 
-			if (selectorName.trim().isEmpty()) {
+			if (selectorName.trim().length() == 0) {
 				throw new IncorrectFormatException(ErrorCode.FOUND_COLON_WHEN_READING_SELECTOR_NAME, "Found an ',' in a selector name without any actual name before it.");
 			}
 


### PR DESCRIPTION
String's isEmpty() is not available in Android < 2.3 and Java < 6. To
fix this two uses of isEmpty() were replaced with length() == 0. This
is more ugly but allows using this library on two outdated platforms.
